### PR TITLE
SWI Prolog switched to Discourse platform

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,7 @@
 ### Community
 
 - [Prolog FAQ](https://www.metalevel.at/prolog/faq) - Frequently Asked Questions list of the SWI-Prolog newsgroup.
+- [SWI-Prolog Discourse](https://swi-prolog.discourse.group/) - Official SWI-Prolog Discourse board.
 - [SWI-Prolog Mailing List](http://www.swi-prolog.org/Mailinglist.html) - Announcements, questions and discussion among SWI-Prolog users.
 - [SWI-Prolog Freenode](http://webchat.freenode.net/?channels=##prolog) - IRC channel of the SWI-Prolog community.
 - [SWI-Prolog Google Group](https://groups.google.com/forum/#!forum/swi-prolog) - SWI-Prolog user


### PR DESCRIPTION
I know, you are going to say "not conforming to guidelines", but the [Google Group is deprecated](https://github.com/klaussinani/awesome-prolog/pull/20), and the primary discussion platform is now Discourse - thus I placed it before any other SWI-Prolog Community links.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**
