### PR TITLE
Remove explicit TOC

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,40 +2,6 @@
 
 > A curated list of open-source Prolog frameworks, libraries and resources.
 
-## Contents
-
-- [API Interfaces](#api-interfaces)
-- [Artificial Intelligence](#artificial-intelligence)
-- [Build Systems](#build-systems)
-- [Compilers](#compilers)
-- [Database](#database)
-- [Date](#date)
-- [Development](#development)
-- [IDE](#ide)
-- [Interpreters](#interpreters)
-- [JSON](#json)
-- [Logging](#logging)
-- [Machine Learning](#machine-learning)
-- [Math](#math)
-- [Miscellaneous](#miscellaneous)
-- [Native](#native)
-- [Object Oriented Programming](#object-oriented-programming)
-- [Parsing](#parsing)
-- [Regular Expressions](#regular-expressions)
-- [REST Frameworks](#rest-frameworks)
-- [Server](#server)
-- [Testing](#testing)
-- [Text Editor Extensions](#text-editor-extensions)
-- [Utilities](#utilities)
-- [Resources](#resources)
-	- [Tutorials](#tutorials)
-	- [Videos](#videos)
-	- [Free Courses](#free-courses)
-	- [Books](#books)
-	- [Community](#community)
-- [Contributing](#contributing)
-- [License](#license)
-
 ## API interfaces
 
 - [twitter_pack](https://github.com/samwalrus/twitter_pack) - Twitter API interface.


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

Github has been providing a table of contents for a few months:
![image](https://user-images.githubusercontent.com/1020565/134220961-f298cb12-f12f-453c-b230-9f45348f4264.png)


I see that you added my last edit to your own ToC https://github.com/klaussinani/awesome-prolog/commit/a922f5cf5fe559df14e71b776ecf32ccc33c7dfd . You shouldn't have to do that since it will sooner or later get out of sync.

So I suggest we use the automatically generated TOC:
